### PR TITLE
support sync generator

### DIFF
--- a/executor/engine/job/process.py
+++ b/executor/engine/job/process.py
@@ -1,9 +1,11 @@
 import asyncio
 import functools
+import inspect
 
 from loky.process_executor import ProcessPoolExecutor
 
 from .base import Job
+from .utils import _gen_initializer, GeneratorWrapper
 
 
 class ProcessJob(Job):
@@ -43,11 +45,15 @@ class ProcessJob(Job):
 
     async def run(self):
         """Run job in process pool."""
-        self._executor = ProcessPoolExecutor(1)
-        loop = asyncio.get_running_loop()
-        func = functools.partial(self.func, **self.kwargs)
-        fut = loop.run_in_executor(self._executor, func, *self.args)
-        result = await fut
+        func = functools.partial(self.func, *self.args, **self.kwargs)
+        if inspect.isgeneratorfunction(self.func): # TODO: support async generator
+            self._executor = ProcessPoolExecutor(1, initializer=_gen_initializer, initargs=(func,))
+            result = GeneratorWrapper(self)
+        else:
+            self._executor = ProcessPoolExecutor(1)
+            loop = asyncio.get_running_loop()
+            fut = loop.run_in_executor(self._executor, func)
+            result = await fut
         return result
 
     async def cancel(self):

--- a/executor/engine/job/process.py
+++ b/executor/engine/job/process.py
@@ -46,7 +46,8 @@ class ProcessJob(Job):
     async def run(self):
         """Run job in process pool."""
         func = functools.partial(self.func, *self.args, **self.kwargs)
-        if inspect.isgeneratorfunction(self.func): # TODO: support async generator
+        if (inspect.isgeneratorfunction(self.func)
+            or inspect.isasyncgenfunction(self.func)):
             self._executor = ProcessPoolExecutor(1, initializer=_gen_initializer, initargs=(func,))
             result = GeneratorWrapper(self)
         else:

--- a/executor/engine/job/utils.py
+++ b/executor/engine/job/utils.py
@@ -34,3 +34,29 @@ class InvalidStateError(ExecutorError):
         super().__init__(
             f"Invalid state: {job} is in {job.status} state, "
             f"but should be in {valid_status} state.")
+
+
+_T = T.TypeVar("_T")
+
+def _gen_initializer(gen_func, args=tuple(), kwargs={}):
+    global _generator
+    _generator = gen_func(*args, **kwargs)
+
+
+def _gen_next():
+    global _generator
+    return next(_generator)
+
+
+class GeneratorWrapper(T.Generic[_T]):
+    """
+    wrap a generator in executor pool
+    """
+    def __init__(self, job: "Job"):
+        self._job = job
+
+    def __iter__(self) :
+        return self
+
+    def __next__(self) -> _T:
+        return self._job._executor.submit(_gen_next).result()


### PR DESCRIPTION
As discussed in #3 , I rewrite ProcessJob.run to support sync generators.
Please review if this approach is appropriate, we can rewrite other Job.run methods and support async generators too.

example code:
```
import typing as t
import asyncio

from executor.engine import Engine, ProcessJob


def func(n: int) -> t.List[int]:
    import time

    time.sleep(1)
    return list(range(n))


def gen(n: int) -> t.Generator[int, None, None]:
    import time

    for i in range(n):
        time.sleep(0.5)
        print(f"sync yield from executor: {i}")
        yield i


async def gen_async(n: int) -> t.AsyncGenerator[int, None]:
    import asyncio

    for i in range(n):
        await asyncio.sleep(0.5)
        print(f"async yield from executor: {i}")
        yield i


async def main():
    with Engine() as engine:
        job1 = ProcessJob(func, (5,))
        engine.submit(job1)
        engine.wait()
        print(job1.result())

        job2 = ProcessJob(gen, (5,))
        engine.submit(job2)
        engine.wait()
        for x in job2.result():
            print(f"main received: {x}")

        job3 = ProcessJob(gen_async, (5,))
        engine.submit(job3)
        engine.wait()
        async for x in job3.result():
            print(f"main received: {x}")

if __name__ == "__main__":
    asyncio.run(main())

```