### PR TITLE
support generator for LocalJob & ThreadJob & DaskJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ from executor.engine import Engine, ProcessJob
 def add(a, b):
     return a + b
 
+async def stream():
+    for i in range(5):
+      await asyncio.sleep(0.5)
+      yield i
+
 with Engine() as engine:
     # job1 and job2 will be executed in parallel
     job1 = ProcessJob(add, args=(1, 2))
@@ -86,6 +91,13 @@ with Engine() as engine:
     engine.submit(job1, job2, job3)
     engine.wait_job(job3)  # wait for job3 done
     print(job3.result())  # 10
+
+    # generator
+    job4 = ProcessJob(stream)
+    # do not do engine.wait because the generator job's future is done only when StopIteration
+    await engine.submit_async(job4)
+    async for x in job3.result():
+      print(x)
 ```
 
 Async mode example:

--- a/executor/engine/job/local.py
+++ b/executor/engine/job/local.py
@@ -6,3 +6,8 @@ class LocalJob(Job):
         """Run job in local thread."""
         res = self.func(*self.args, **self.kwargs)
         return res
+
+    async def run_generator(self):
+        """Run job as a generator."""
+        res = self.func(*self.args, **self.kwargs)
+        return res

--- a/executor/engine/job/utils.py
+++ b/executor/engine/job/utils.py
@@ -10,7 +10,6 @@ from ..utils import CheckAttrRange, ExecutorError
 if T.TYPE_CHECKING:
     from .base import Job
 
-
 JobStatusType = T.Literal['pending', 'running', 'failed', 'done', 'cancelled']
 valid_job_statuses: T.List[JobStatusType] = [
     'pending', 'running', 'failed', 'done', 'cancelled']
@@ -40,7 +39,7 @@ class InvalidStateError(ExecutorError):
 
 
 _T = T.TypeVar("_T")
-
+_thread_locals = threading.local()
 
 def _gen_initializer(gen_func, args=tuple(), kwargs={}):  # pragma: no cover
     global _thread_locals
@@ -50,7 +49,7 @@ def _gen_initializer(gen_func, args=tuple(), kwargs={}):  # pragma: no cover
     _thread_locals._generator = gen_func(*args, **kwargs)
 
 
-def _gen_next(fut: T.Optional[Future] = None):  # pragma: no cover
+def _gen_next(fut = None):  # pragma: no cover
     global _thread_locals
     if fut is None:
         return next(_thread_locals._generator)
@@ -58,7 +57,7 @@ def _gen_next(fut: T.Optional[Future] = None):  # pragma: no cover
         return next(fut)
 
 
-def _gen_anext(fut: T.Optional[Future] = None):  # pragma: no cover
+def _gen_anext(fut = None):  # pragma: no cover
     global _thread_locals
     if fut is None:
         return asyncio.run(_thread_locals._generator.__anext__())

--- a/executor/engine/job/utils.py
+++ b/executor/engine/job/utils.py
@@ -41,6 +41,7 @@ class InvalidStateError(ExecutorError):
 _T = T.TypeVar("_T")
 _thread_locals = threading.local()
 
+
 def _gen_initializer(gen_func, args=tuple(), kwargs={}):  # pragma: no cover
     global _thread_locals
     if "_thread_locals" not in globals():
@@ -49,7 +50,7 @@ def _gen_initializer(gen_func, args=tuple(), kwargs={}):  # pragma: no cover
     _thread_locals._generator = gen_func(*args, **kwargs)
 
 
-def _gen_next(fut = None):  # pragma: no cover
+def _gen_next(fut=None):  # pragma: no cover
     global _thread_locals
     if fut is None:
         return next(_thread_locals._generator)
@@ -57,7 +58,7 @@ def _gen_next(fut = None):  # pragma: no cover
         return next(fut)
 
 
-def _gen_anext(fut = None):  # pragma: no cover
+def _gen_anext(fut=None):  # pragma: no cover
     global _thread_locals
     if fut is None:
         return asyncio.run(_thread_locals._generator.__anext__())
@@ -69,6 +70,7 @@ class GeneratorWrapper(T.Generic[_T]):
     """
     wrap a generator in executor pool
     """
+
     def __init__(self, job: "Job", fut: T.Optional[Future] = None):
         self._job = job
         self._fut = fut


### PR DESCRIPTION
known problem:
DaskJob will logs `StopIteration` error even runs success.

example code:
```
import typing as t
import asyncio

from executor.engine import Engine, ProcessJob, LocalJob, ThreadJob
from executor.engine.job.dask import DaskJob


def gen(n: int) -> t.Generator[int, None, None]:
    import time

    for i in range(n):
        time.sleep(0.5)
        print(f"sync yield from executor: {i}")
        yield i


async def gen_async(n: int) -> t.AsyncGenerator[int, None]:
    import asyncio

    for i in range(n):
        await asyncio.sleep(0.5)
        print(f"async yield from executor: {i}")
        yield i


async def main():
    with Engine() as engine:
        for job_cls in [LocalJob, ThreadJob, ProcessJob, DaskJob]:
            job1 = job_cls(gen, (5,))
            engine.submit(job1)
            for x in job1.result():
                print(f"main received: {x}")

            job2 = job_cls(gen_async, (5,))
            engine.submit(job2)
            async for x in job2.result():
                print(f"main received: {x}")
            print(job2)


if __name__ == "__main__":
    asyncio.run(main())
```